### PR TITLE
Setter opp antall tråder, hvis ikke leser den ikke fra kafka

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -62,7 +62,7 @@ fun doReadynessCheck(): Boolean {
 
 data class ApplicationState(var running: Boolean = true, var initialized: Boolean = false)
 
-val coroutineContext = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
+val coroutineContext = Executors.newFixedThreadPool(2).asCoroutineDispatcher()
 
 val log: Logger = LoggerFactory.getLogger("nav.syfo.papirmottak")
 

--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -62,7 +62,7 @@ fun doReadynessCheck(): Boolean {
 
 data class ApplicationState(var running: Boolean = true, var initialized: Boolean = false)
 
-val coroutineContext = Executors.newFixedThreadPool(2).asCoroutineDispatcher()
+val coroutineContext = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
 
 val log: Logger = LoggerFactory.getLogger("nav.syfo.papirmottak")
 
@@ -153,7 +153,7 @@ fun CoroutineScope.createListener(applicationState: ApplicationState, action: su
         }
 
 @KtorExperimentalAPI
-fun CoroutineScope.launchListeners(
+suspend fun CoroutineScope.launchListeners(
     env: Environment,
     applicationState: ApplicationState,
     consumerProperties: Properties,
@@ -168,7 +168,7 @@ fun CoroutineScope.launchListeners(
         }
     }.toList()
 
-    runBlocking { journalfoeringHendelseListeners.forEach { it.join() } }
+    journalfoeringHendelseListeners.forEach { it.join() }
 }
 
 @KtorExperimentalAPI

--- a/src/main/kotlin/no/nav/syfo/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/BehandlingService.kt
@@ -35,7 +35,7 @@ class BehandlingService constructor(
 
             if (journalfoeringEvent.temaNytt.toString() == "SYM" &&
                     journalfoeringEvent.mottaksKanal.toString() == "SKAN_NETS" &&
-                    journalfoeringEvent.hendelsesType == "MidlertidigJournalført"
+                    journalfoeringEvent.hendelsesType.toString() == "MidlertidigJournalført"
             ) {
                 val requestLatency = REQUEST_TIME.startTimer()
                 PAPIRSM_MOTTATT.inc()
@@ -73,6 +73,8 @@ class BehandlingService constructor(
                 val currentRequestLatency = requestLatency.observeDuration()
 
                 log.info("Finished processing took {}s, {}", StructuredArguments.keyValue("latency", currentRequestLatency), fields(loggingMeta))
+            } else {
+                log.info("Mottatt jp som ikke treffer filter, tema = ${journalfoeringEvent.temaNytt}, mottakskanal = ${journalfoeringEvent.mottaksKanal}, hendelsestype = ${journalfoeringEvent.hendelsesType}, journalpostid = $journalpostId")
             }
         }
     }


### PR DESCRIPTION
Jeg ser ikke sånn umiddelbart hva det er som legger beslag på tråden når vi kjører med kun en tråd, men det er rimelig klart at med kun en tråd leser den ikke fra kafka :/

Loggingen la jeg på sånn at vi ser at den faktisk leser fra topicen. Det er mulig vi ikke trenger den i prod, men enn så lenge er den nyttig :)