### PR TITLE
TemaEndret

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -165,7 +165,7 @@ fun main() {
             arbeidsfordelingClient = arbeidsFordelingClient)
     val sykmeldingService = SykmeldingService(sakClient, oppgaveService, safDokumentClient, norskHelsenettClient, regelClient, kuhrsarClient, pdlPersonService, behandlendeEnhetService)
     val utenlandskSykmeldingService = UtenlandskSykmeldingService(sakClient, oppgaveService)
-    val behandlingService = BehandlingService(safJournalpostClient, sykmeldingService, utenlandskSykmeldingService, pdlPersonService)
+    val behandlingService = BehandlingService(safJournalpostClient, sykmeldingService, utenlandskSykmeldingService, pdlPersonService, oppgaveService)
 
     launchListeners(
             env,

--- a/src/main/kotlin/no/nav/syfo/client/SafJournalpostClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/SafJournalpostClient.kt
@@ -61,7 +61,9 @@ class SafJournalpostClient(private val apolloClient: ApolloClient, private val s
     }
 
     private fun erIkkeJournalfort(journalstatus: type.Journalstatus?): Boolean {
-        return journalstatus?.name?.equals("MOTTATT", true) ?: false
+        return journalstatus?.name?.let {
+            it.equals("MOTTATT", true) || it.equals("FEILREGISTRERT", true)
+        } ?: false
     }
 }
 

--- a/src/main/kotlin/no/nav/syfo/metrics/MetricsRegistry.kt
+++ b/src/main/kotlin/no/nav/syfo/metrics/MetricsRegistry.kt
@@ -16,6 +16,12 @@ val PAPIRSM_MOTTATT: Counter = Counter.build()
     .help("Antall mottatte papirsykmeldinger")
     .register()
 
+val ENDRET_PAPIRSM_MOTTATT: Counter = Counter.build()
+    .namespace(NAMESPACE)
+    .name("mottatt_endretpapirsykmelding_count")
+    .help("Antall mottatte papirsykmeldinger, tema endret")
+    .register()
+
 val PAPIRSM_MOTTATT_NORGE: Counter = Counter.build()
     .namespace(NAMESPACE)
     .name("mottatt_norsk_papirsykmelding_count")

--- a/src/main/kotlin/no/nav/syfo/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/BehandlingService.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.client.SafJournalpostClient
 import no.nav.syfo.domain.JournalpostMetadata
 import no.nav.syfo.domain.PapirSmRegistering
 import no.nav.syfo.log
+import no.nav.syfo.metrics.ENDRET_PAPIRSM_MOTTATT
 import no.nav.syfo.metrics.PAPIRSM_MOTTATT
 import no.nav.syfo.metrics.REQUEST_TIME
 import no.nav.syfo.model.ReceivedSykmelding
@@ -50,6 +51,10 @@ class BehandlingService(
                 val requestLatency = REQUEST_TIME.startTimer()
                 PAPIRSM_MOTTATT.inc()
                 log.info("Mottatt papirsykmelding fra mottakskanal {}, {}", journalfoeringEvent.mottaksKanal, fields(loggingMeta))
+                if (journalfoeringEvent.hendelsesType.toString() == "TemaEndret") {
+                    ENDRET_PAPIRSM_MOTTATT.inc()
+                    log.info("Mottatt endret journalpost {}", fields(loggingMeta))
+                }
                 val journalpostMetadata = safJournalpostClient.getJournalpostMetadata(journalpostId, loggingMeta)
                         ?: throw IllegalStateException("Unable to find journalpost with id $journalpostId")
 

--- a/src/main/kotlin/no/nav/syfo/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/BehandlingService.kt
@@ -45,7 +45,7 @@ class BehandlingService(
 
             if (journalfoeringEvent.temaNytt.toString() == "SYM" &&
                     (journalfoeringEvent.mottaksKanal.toString() == "SKAN_NETS" || journalfoeringEvent.mottaksKanal.toString() == "SKAN_IM") &&
-                    journalfoeringEvent.hendelsesType.toString() == "MidlertidigJournalført" || journalfoeringEvent.hendelsesType.toString() == "TemaEndret"
+                (journalfoeringEvent.hendelsesType.toString() == "MidlertidigJournalført" || journalfoeringEvent.hendelsesType.toString() == "TemaEndret")
             ) {
                 val requestLatency = REQUEST_TIME.startTimer()
                 PAPIRSM_MOTTATT.inc()


### PR DESCRIPTION
Vi ønsker å håndtere journalposter som endres til å få tema=SYM og som ikke er ferdigstilt. 

Siden vi allerede sjekker om tilsvarende oppgave finnes ved oppretting av fordelingsoppgave (og journalføringsoppgave) trenger vi bare sjekke at det ikke finnes en oppgave før vi forsøker å digitalisere sykmeldingen. Hvis ikke ville vi risikert at det ble opprettet oppgave for en sykmelding som har gått inn i den digitale løypa. 